### PR TITLE
イレギュラーシフト申請画面の調整

### DIFF
--- a/fuel/app/views/irregular/request.php
+++ b/fuel/app/views/irregular/request.php
@@ -1,3 +1,5 @@
+<?php //$entrue="uk-button-primary uk-active";$enfalse="uk-button-success"; ?>
+<?php $entrue="uk-button-success uk-active";$enfalse=""; ?>
 <h6 class="uk-article-title">
 	<?php echo $irregular_shift->irregular_name; ?>の<?php echo $set; ?>
 </h6>
@@ -19,55 +21,50 @@
 		<tr>
 			<td class="uk-text-center"><?php echo $irregular_day->irregular_day_name; ?></td>
 			<td class="uk-text-center">
-				<div class="uk-button-group" data-uk-button-checkbox>
-<?php if($irregular_user[$i]->request_shift_type==4){$shift_type=NULL;}else{$shift_type=$irregular_user[$i]->request_shift_type;} ?>
-<?php if($shift_type%2==1){$am_active=" uk-active";}else{$am_active=NULL;} ?>
-<?php if($shift_type>=2){$pm_active=" uk-active";}else{$pm_active=NULL;} ?>
-					<button class="uk-button uk-button-success<?php echo $am_active; ?>" type="button" onClick=invalueAM<?php echo $i; ?>()><i class="fa fa-sun-o"></i> 10時~13時(午前)</button>
-					<button class="uk-button uk-button-success<?php echo $pm_active; ?>" type="button" onClick=invaluePM<?php echo $i; ?>()><i class="fa fa-moon-o"></i> 13時~17時(午後)</button>
+				<div class="uk-button-group" >
+<?php if($irregular_user[$i]->request_shift_type==4){$shift_type=0;}else{$shift_type=$irregular_user[$i]->request_shift_type;} ?>
+<?php if($shift_type%2==1){$am_active=$entrue;}else{$am_active=$enfalse;} ?>
+<?php if($shift_type>=2){$pm_active=$entrue;}else{$pm_active=$enfalse;} ?>
+					<button class="uk-button shift_button <?php echo $am_active; ?>" type="button" value="1"><i class="fa fa-sun-o"></i> 10時~13時(午前)</button>
+					<button class="uk-button shift_button <?php echo $pm_active; ?>" type="button" value="2"><i class="fa fa-moon-o"></i> 13時~17時(午後)</button>
 				</div>
+				<?php echo Form::hidden('irregular_type_id'.$i,$shift_type,array('class'=>'hidden_field'))."\n"; ?>
 			</td>
 			<td class="uk-text-center">
 				<?php echo Form::input('user_comment'.$i,$irregular_user[$i]->user_comment,array('class'=>''))."\n"; ?>
-			</td>
-			<td class="uk-text-center">
-				<?php echo Form::hidden('irregular_type_id'.$i,$shift_type,array('id'=>'hidden_value'.$i))."\n"; ?>
-				<?php echo Form::hidden('hidden_value'.$i.'_for_skip',1,array('id'=>'for_skip'.$i))."\n"; ?>
-				<script>
-					<!--
-					function invalueAM<?php echo $i; ?>(){
-						if(document.getElementById("for_skip<?php echo $i; ?>").value==1){
-							document.getElementById("for_skip<?php echo $i; ?>").value = 0;
-						}else{
-							var val = Number(document.getElementById("hidden_value<?php echo $i; ?>").value);
-							if(val%2==1){
-								document.getElementById("hidden_value<?php echo $i; ?>").value = val-1;
-							}else{
-								document.getElementById("hidden_value<?php echo $i; ?>").value = val+1;
-							}
-						}
-					}
-					function invaluePM<?php echo $i; ?>(){
-						if(document.getElementById("for_skip<?php echo $i; ?>").value==1){
-							document.getElementById("for_skip<?php echo $i; ?>").value = 0;
-						}else{
-							var val = Number(document.getElementById("hidden_value<?php echo $i; ?>").value);
-							document.getElementById("hidden_value<?php echo $i; ?>").value = val;
-							if(val>=2){
-								document.getElementById("hidden_value<?php echo $i; ?>").value = val-2;
-							}else{
-								document.getElementById("hidden_value<?php echo $i; ?>").value = val+2;
-							}
-						}
-					}
-					//-->
-				</script>
 			</td>
 		</tr>
 <?php $i++; ?>
 <?php endforeach; ?>
 	</tbody>
 </table>
+				<script>
+					<!--
+					$(function(){
+						$('.shift_button').click(function(){
+							$(this).toggleClass('<?php echo $entrue." ".$enfalse; ?>');
+							var thisval = $(this).val();
+							var hideval = $(this).parent().next(".hidden_field").val();
+							var setval;
+							if(thisval==1){
+								if(hideval%2==0){
+									setval = Number(hideval)+1;
+								}else{
+									setval = Number(hideval)-1;
+								}
+							}else{
+								if(hideval<2){
+									setval = Number(hideval)+2;
+								}else{
+									setval = Number(hideval)-2;
+								}
+							}
+							$(this).parent().next(".hidden_field").val(setval);
+//							alert("thisval = "+thisval+"\nhideval = "+hideval+"\nsetval = "+setval);
+						});
+					});
+					//-->
+				</script>
 <button style="text-align: center;" class="uk-button uk-button-primary uk-h3" type="submit">&nbsp;&nbsp;この内容で<?php echo $set; ?>する&nbsp;<i class="fa fa-share"></i>&nbsp;&nbsp;</button>
 <?php echo Form::close(); ?>
 <pre>


### PR DESCRIPTION
先に動作確認などしてもらった方が良さげですね。
uikitが提供しているボタンの操作を切ってjQueryで実装したので、
もしかすると不具合が起きるかも?

以下今回やったこと

●uikitの提供しているボタンの切り替えでは違いが分かりにくいため、
　任意のボタンのクラスに変更できるようにjQueryで新たに実装した。

●ついでに、気持ち悪いぐらいのJavaScriptの力技で実装した機能を
　jQueryで修正・再現した。

補足:
「任意のボタンのクラスに変更できる」については、
view/irregular/request.phpの一番上に記述しているPHPの文で制御しています。
$entrueが入力されている場合のボタン、$enfalseが入力されていない場合のボタンのクラスになります。
詳しく知りたい方は西本まで。
